### PR TITLE
prevent exception when ProgramFiles env is not set

### DIFF
--- a/PSLauncher/Util.cs
+++ b/PSLauncher/Util.cs
@@ -126,8 +126,11 @@ namespace PSLauncher
             pathsToCheck.Add(psFolder);
 
             // worth a shot! (for windows XP or old installs)
-            psFolder = Path.Combine(ProgramFilesx86(), "Sony\\PlanetSide");
-            pathsToCheck.Add(psFolder);
+            string programFiles = ProgramFilesx86();
+            if(programFiles != null) {
+                psFolder = Path.Combine(programFiles, "Sony\\PlanetSide");
+                pathsToCheck.Add(psFolder);
+            }
 
             int i = 1;
             foreach(var path in pathsToCheck)


### PR DESCRIPTION
This probably only occurs in non-Windows environments (Wine).

If the `ProgramFiles` environment variable is not set, `ProgramFilesx86()` will return `null`, which causes `Path.Combine` to throw a `ArgumentNullException`.

**I don't have a dev setup for C# so I didn't actually test this.**